### PR TITLE
Run print instead of return

### DIFF
--- a/python-package/mc2client/opaquesql/opaquesql.py
+++ b/python-package/mc2client/opaquesql/opaquesql.py
@@ -25,4 +25,6 @@ def run(script):
         response = _check_remote_call(
             stub.ReceiveQuery(opaquesql_pb2.QueryRequest(request=code))
         )
-        return response.result
+        # response.result is an unparsed string containing
+        # the return of the script as well as stdout.
+        print(response.result)


### PR DESCRIPTION
Print in Python automatically parses things such as `\n` so it works.

I don't see a case where the output of this file should just be a raw string, since `response.result` is Scala output.

What it looks like now:
![Screen Shot 2021-04-05 at 1 38 24 PM](https://user-images.githubusercontent.com/34696537/113628430-bb8f1f80-9619-11eb-854c-a966b398735f.png)
