### PR TITLE
Revert "Bump cryptography from 3.3.1 to 3.3.2 in /client-docs"

### DIFF
--- a/client-docs/requirements.txt
+++ b/client-docs/requirements.txt
@@ -6,7 +6,7 @@ azure-mgmt-network==10.0.0
 azure-cli-core
 azure-storage-blob
 azure-identity
-cryptography==3.3.2
+cryptography==3.3.1
 grpcio
 grpcio-tools
 jsonschema


### PR DESCRIPTION
Reverts mc2-project/mc2#150 until we figure out the build issue