### PR TITLE
Change mc2.py directory in docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -109,3 +109,10 @@ jobs:
           branch: gh-pages
           directory: main/gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
+    
+      - name: Update MC2 website
+          uses: peter-evans/repository-dispatch@v1
+          with:
+            token: ${{ secrets.MC2_BOT_PAT }}
+            repository: mc2-project/mc2-project.github.io
+            event-type: client-docs-dispatch

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,6 +75,12 @@ jobs:
         run: cd sequencefile; python setup.py install
         shell: bash
 
+      - name: Little hack to make this repo's docs build properly
+        run: |
+          cd main/client-docs
+          mkdir -p _build/tmp
+          cp ../mc2.py _build/tmp
+
       - name: Build docs
         run: |
           cd main/client-docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -111,8 +111,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
     
       - name: Update MC2 website
-          uses: peter-evans/repository-dispatch@v1
-          with:
-            token: ${{ secrets.MC2_BOT_PAT }}
-            repository: mc2-project/mc2-project.github.io
-            event-type: client-docs-dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.MC2_BOT_PAT }}
+          repository: mc2-project/mc2-project.github.io
+          event-type: client-docs-dispatch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,6 +191,12 @@ jobs:
         run: cd sequencefile; python setup.py install
         shell: bash
 
+      - name: Little hack to make this repo's docs build properly
+        run: |
+          cd main/client-docs
+          mkdir -p _build/tmp
+          cp ../mc2.py _build/tmp
+
       - name: Build docs
         run: |
           cd main/client-docs

--- a/client-docs/cli/api.rst
+++ b/client-docs/cli/api.rst
@@ -4,6 +4,6 @@ CLI Reference
 See the :doc:`Configuration <../config/config>` section on how to specify parameters for each command.
 
 .. argparse::
-   :filename: ../mc2.py
+   :filename: _build/tmp/mc2.py
    :func: parser
    :prog: mc2


### PR DESCRIPTION
In preparation for [documentation consolidation](https://github.com/mc2-project/mc2-project.github.io/pull/1) across the MC<sup>2</sup> ecosystem, this PR changes the path of `mc2.py`, used for auto-generating documentation. This change will break the documentation at https://mc2-project.github.io/mc2/cli/api.html temporarily until the consolidation is finished.