### PR TITLE
Add GitHub action to auto PR on branch push

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,15 @@
+name: Pull Request on update- branch push
+
+# Trigger this workflow on a push to any branch in this repo
+on: push
+jobs:
+  auto-pull-request:
+    name: PullRequestAction
+    runs-on: ubuntu-latest
+    steps:
+      - name: pull-request-action
+        uses: vsoch/pull-request-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_PREFIX: "update-"
+          PULL_REQUEST_BRANCH: "master"


### PR DESCRIPTION
This PR adds an action that will automatically create a PR when branches with the prefix `update-` are pushed to the repo. The PR is from the `update-*` branch to `master`.