### PR TITLE
Fixing auto pr

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -10,6 +10,6 @@ jobs:
       - name: pull-request-action
         uses: vsoch/pull-request-action@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MC2_BOT_PAT }}
           BRANCH_PREFIX: "update-"
           PULL_REQUEST_BRANCH: "master"


### PR DESCRIPTION
Due to [this issue](https://github.com/vsoch/pull-request-action/issues/30), CI doesn't run when a PR is automatically created using `secrets.GITHUB_TOKEN`. We change the token from `GITHUB_TOKEN` to the `MC2_BOT_PAT` to (hopefully) run the CI on every opened automated PR.