### PR TITLE
Scala demo script/docs cleanup

### DIFF
--- a/client-docs/quickstart.rst
+++ b/client-docs/quickstart.rst
@@ -38,7 +38,7 @@ If you'd like to try everything out locally, you can do so within the Docker con
 
     |cmd| upload
 
-5. Run the provided Opaque SQL quickstart script, to be executed by MC\ :sup:`2`. The script can be found `here <https://github.com/mc2-project/mc2/quickstart/opaque_sql_demo.scala>`_.
+5. Run the provided Opaque SQL quickstart script, to be executed by MC\ :sup:`2`. The script can be found `here <https://github.com/mc2-project/mc2/blob/master/quickstart/opaque_sql_demo.scala>`_.
 
 .. code-block:: bash
     :substitutions:
@@ -102,7 +102,7 @@ Once you've done that, launch the resources.
 
     |cmd| upload
 
-6. Run the provided Opaque SQL demo script, to be executed by MC\ :sup:`2`. The script can be found `here <https://github.com/opaque-systems/opaque-client/blob/master/quickstart/opaque_sql_demo.scala>`_ , and performs a filter operation over our data -- the results will contain records of all patients who are younger than 30 years old. Results are encrypted by MC\ :sup:`2` before being saved, and can only be decrypted with the key you used to encrypt your data in the previous step.
+6. Run the provided Opaque SQL demo script, to be executed by MC\ :sup:`2`. The script can be found `here <https://github.com/mc2-project/mc2/blob/master/quickstart/opaque_sql_demo.scala>`_ , and performs a filter operation over our data -- the results will contain records of all patients who are younger than 30 years old. Results are encrypted by MC\ :sup:`2` before being saved, and can only be decrypted with the key you used to encrypt your data in the previous step.
 
 .. code-block:: bash
     :substitutions:

--- a/demo/opaque_sql_demo.scala
+++ b/demo/opaque_sql_demo.scala
@@ -2,8 +2,8 @@ import edu.berkeley.cs.rise.opaque.implicits._
 import org.apache.spark.sql.types._
 
 val df = spark.read.format("edu.berkeley.cs.rise.opaque.EncryptedSource").load("/root/data/opaquesql.csv.enc")
+
 val result = df.filter($"Age" < lit(30))
+
 // This will save the result DataFrame to the result directory on the cloud
 result.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save("/root/results/opaque_sql_result")
-
-

--- a/demo/opaquesql/opaque_sql_demo.scala
+++ b/demo/opaquesql/opaque_sql_demo.scala
@@ -2,8 +2,8 @@ import edu.berkeley.cs.rise.opaque.implicits._
 import org.apache.spark.sql.types._
 
 val df = spark.read.format("edu.berkeley.cs.rise.opaque.EncryptedSource").load("/tmp/opaquesql.csv.enc")
+
 val result = df.filter($"Age" < lit(30))
+
 // This will save the result DataFrame to the result directory on the cloud
 result.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save("/tmp/opaque_sql_result")
-
-

--- a/quickstart/opaque_sql_demo.scala
+++ b/quickstart/opaque_sql_demo.scala
@@ -2,8 +2,8 @@ import edu.berkeley.cs.rise.opaque.implicits._
 import org.apache.spark.sql.types._
 
 val df = spark.read.format("edu.berkeley.cs.rise.opaque.EncryptedSource").load("/mc2/data/opaquesql.csv.enc")
+
 val result = df.filter($"Age" < lit(30))
+
 // This will save the result DataFrame to the result directory on the cloud
 result.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save("/mc2/opaque-sql/opaque_sql_result")
-
-


### PR DESCRIPTION
When working on the Pyspark docs, I noticed a couple of issues.

1. The Scala demo scripts' formats are a little weird, with 2 extra spaces at the end.
2. https://github.com/mc2-project/mc2/quickstart/opaque_sql_demo.scala in the docs is a dead link
3. There was an opaque-systems/opaque-client URL instead of mc2-project/mc2