### PR TITLE
Eliminate strict sphinx version requirement

### DIFF
--- a/client-docs/requirements.txt
+++ b/client-docs/requirements.txt
@@ -17,7 +17,7 @@ numpydoc
 pandas
 pytest
 pyyaml
-sphinx==3.0.3
+sphinx
 sphinx-argparse
 sphinx-copybutton
 sphinxcontrib-spelling


### PR DESCRIPTION
This sphinx version conflicts with other packages, and causes the build time to be enormous before eventually failing. Eliminating the strict sphinx version requirement fixes this issue.